### PR TITLE
Implement new HTTPS requirement behavior

### DIFF
--- a/config/default.yml
+++ b/config/default.yml
@@ -144,6 +144,7 @@ strip_cookies:
 default_host: localhost
 site_name: API Umbrella
 apiSettings:
+  require_https: required_return_error
   rate_limits:
     - duration: 1000
       accuracy: 500
@@ -226,3 +227,7 @@ apiSettings:
       status_code: 500
       code: INTERNAL_SERVER_ERROR
       message: An unexpected error has occurred. Try again later or contact us at {{baseUrl}}/contact for assistance
+    https_required:
+      status_code: 400
+      code: HTTPS_REQUIRED
+      message: "Requests must be made over HTTPS. Try accessing the API at: {{httpsUrl}}"

--- a/test/config/test.yml
+++ b/test/config/test.yml
@@ -194,6 +194,28 @@ apis:
     url_matches:
       - frontend_prefix: /dns/no-drops-during-changes/
         backend_prefix: /
+  - _id: https-requirements-error
+    frontend_host: "*"
+    backend_host: localhost
+    servers:
+      - host: localhost
+        port: 9444
+    url_matches:
+      - frontend_prefix: /info/https/required_return_error/
+        backend_prefix: /info/
+    settings:
+      require_https: required_return_error
+  - _id: https-requirements-redirect
+    frontend_host: "*"
+    backend_host: localhost
+    servers:
+      - host: localhost
+        port: 9444
+    url_matches:
+      - frontend_prefix: /info/https/required_return_redirect/
+        backend_prefix: /info/
+    settings:
+      require_https: required_return_redirect
   - _id: example
     frontend_host: localhost
     backend_host: localhost
@@ -215,3 +237,5 @@ apis:
 dns_resolver:
   minimum_ttl: 1
   reload_buffer_time: 1
+apiSettings:
+  require_https: optional

--- a/test/integration/https_requirements.js
+++ b/test/integration/https_requirements.js
@@ -1,0 +1,67 @@
+'use strict';
+
+require('../test_helper');
+
+var _ = require('lodash'),
+    request = require('request');
+
+describe('https requirements', function() {
+  beforeEach(function(done) {
+    Factory.create('api_user', { settings: { rate_limit_mode: 'unlimited' } }, function(user) {
+      this.apiKey = user.api_key;
+      this.options = {
+        strictSSL: false,
+        followRedirect: false,
+        headers: {
+          'X-Api-Key': this.apiKey,
+          'X-Disable-Router-Connection-Limits': 'yes',
+          'X-Disable-Router-Rate-Limits': 'yes',
+        },
+      };
+
+      done();
+    }.bind(this));
+  });
+
+  it('https redirects include the original host and URL including api key', function(done) {
+    var options = _.merge({}, this.options, {
+      headers: {
+        'Host': 'unknown.foo',
+      },
+    });
+    request.get('http://localhost:9080/info/https/required_return_redirect/?foo=bar&test1=test2&api_key=' + this.apiKey, options, function(error, response) {
+      should.not.exist(error);
+      response.statusCode.should.eql(301);
+      response.headers.location.should.eql('https://unknown.foo:9081/info/https/required_return_redirect/?foo=bar&test1=test2&api_key=' + this.apiKey);
+      done();
+    }.bind(this));
+  });
+
+  it('POST requests result in a 307 redirect', function(done) {
+    var options = _.merge({}, this.options, {
+      headers: {
+        'Host': 'unknown.foo',
+      },
+    });
+    request.post('http://localhost:9080/info/https/required_return_redirect/?foo=bar&test1=test2', options, function(error, response) {
+      should.not.exist(error);
+      response.statusCode.should.eql(307);
+      response.headers.location.should.eql('https://unknown.foo:9081/info/https/required_return_redirect/?foo=bar&test1=test2');
+      done();
+    });
+  });
+
+  it('returns the https url in the error message', function(done) {
+    var options = _.merge({}, this.options, {
+      headers: {
+        'Host': 'unknown.foo',
+      },
+    });
+    request.post('http://localhost:9080/info/https/required_return_error/?foo=bar&test1=test2', options, function(error, response, body) {
+      should.not.exist(error);
+      response.statusCode.should.eql(400);
+      body.should.include('https://unknown.foo:9081/info/https/required_return_error/?foo=bar&test1=test2');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
Now each API backend can choose to require HTTPS with either an error message instructing the user to use HTTPS or a redirect. There's also support for a "transition" mode where existing API keys can continue calling the API via HTTP, but all new api keys must use HTTPS.

Related to https://github.com/18F/api.data.gov/issues/34