### PR TITLE
Configurable system-wide URL redirects

### DIFF
--- a/templates/etc/nginx/frontend_hosts.conf.hbs
+++ b/templates/etc/nginx/frontend_hosts.conf.hbs
@@ -36,6 +36,10 @@ server {
     rewrite .* /api-umbrella-banned last;
   }
 
+  {{~#each rewrites}}
+    rewrite {{{.}}};
+  {{~/each}}
+
   {{~#if enable_web_backend}}
     # Route the dynamic portions of the site to the Rails web app.
     location ~* {{../../router.web_backend_regex}} {

--- a/test/config/test.yml
+++ b/test/config/test.yml
@@ -269,9 +269,16 @@ website_backends:
 hosts:
   - hostname: default.foo
     default: true
+    rewrites:
+      - "^/admin/rewrite_me$ https://example.com/ permanent"
+      - "^/hello/rewrite/(debian|el|ubuntu)/([\\d\\.]+)/(file[_-]([\\d\\.]+)-\\d+).*((\\.|_)(amd64|x86_64).(deb|rpm)) https://example.com/downloads/v$4/$3.$1$2$5? redirect"
+      - "^/hello/rewrite https://example.com/something/ permanent"
   - hostname: withweb.foo
     enable_web_backend: true
   - hostname: withoutweb.foo
+  - hostname: with-apis-and-website.foo
+    rewrites:
+      - "^/example/rewrite_me$ https://example.com/ permanent"
 dns_resolver:
   minimum_ttl: 1
   reload_buffer_time: 1

--- a/test/integration/url_rewrites.js
+++ b/test/integration/url_rewrites.js
@@ -1,0 +1,95 @@
+'use strict';
+
+require('../test_helper');
+
+var _ = require('lodash'),
+    request = require('request');
+
+describe('url rewrites', function() {
+  beforeEach(function() {
+    this.options = {
+      followRedirect: false,
+      strictSSL: false,
+    };
+  });
+
+  it('performs simple nginx style rewrites on a per host basis', function(done) {
+    var options = _.merge({}, this.options, {
+      headers: {
+        'Host': 'default.foo',
+      },
+    });
+    request.get('http://localhost:9080/hello/rewrite?foo=bar', options, function(error, response) {
+      should.not.exist(error);
+      response.statusCode.should.eql(301);
+      response.headers.location.should.eql('https://example.com/something/?foo=bar');
+      done();
+    });
+  });
+
+  it('performs more complex nginx style rewrites on a per host basis', function(done) {
+    var options = _.merge({}, this.options, {
+      headers: {
+        'Host': 'default.foo',
+      },
+    });
+    request.get('http://localhost:9080/hello/rewrite/el/7/file-0.6.0-1.el7.x86_64.rpm?foo=bar', options, function(error, response) {
+      should.not.exist(error);
+      response.statusCode.should.eql(302);
+      response.headers.location.should.eql('https://example.com/downloads/v0.6.0/file-0.6.0-1.el7.x86_64.rpm');
+      done();
+    });
+  });
+
+  it('rewrites take precendence over potential API matches', function(done) {
+    var options = _.merge({}, this.options, {
+      headers: {
+        'Host': 'with-apis-and-website.foo',
+      },
+    });
+    request.get('http://localhost:9080/example/rewrite_me', options, function(error, response) {
+      should.not.exist(error);
+      response.statusCode.should.eql(301);
+      response.headers.location.should.eql('https://example.com/');
+
+      request.get('http://localhost:9080/example/rewrite_me_just_kidding', options, function(error, response, body) {
+        should.not.exist(error);
+        response.statusCode.should.eql(403);
+        body.should.contain('API_KEY_MISSING');
+        done();
+      });
+    });
+  });
+
+  it('rewrites take precendence over potential web admin matches', function(done) {
+    var options = _.merge({}, this.options, {
+      headers: {
+        'Host': 'default.foo',
+      },
+    });
+    request.get('https://localhost:9081/admin/rewrite_me', options, function(error, response) {
+      should.not.exist(error);
+      response.statusCode.should.eql(301);
+      response.headers.location.should.eql('https://example.com/');
+
+      request.get('https://localhost:9081/admin/rewrite_me_just_kidding', options, function(error, response) {
+        should.not.exist(error);
+        response.statusCode.should.eql(404);
+        done();
+      });
+    });
+  });
+
+  it('does not perform rewrites on other hosts', function(done) {
+    var options = _.merge({}, this.options, {
+      headers: {
+        'Host': 'withweb.foo',
+      },
+    });
+    request.get('http://localhost:9080/hello/rewrite?foo=bar', options, function(error, response) {
+      should.not.exist(error);
+      response.statusCode.should.eql(404);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This adds the ability to setup arbitrary system-wide URL redirects at a global, nginx-level. This is currently only configurable via the YAML config file, and not the web admin, but it's primarily targeted at lower-level or redirects needed during initial (but we could expand the functionality if it's useful). This may be useful for setting up API Umbrella on a host that may have had legacy redirects in place.